### PR TITLE
Switch to Open JDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | te
 RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
-RUN apt-get install -yq --allow-unauthenticated oracle-java8-installer git
+RUN apt-get install -yq openjdk-8-jdk
 
 RUN git clone https://github.com/synthetichealth/synthea.git && \
     cd synthea && \


### PR DESCRIPTION
The Dockerfile currently references Oracle's installer which no longer allows unauthenticated installs, so the image fails to build with the error E: Package 'oracle-java8-installer' has no installation candidate